### PR TITLE
Rename ReactiveOps to Fairwinds

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 ReactiveOps
+   Copyright 2017 FairwindsOps Inc
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "k8s-scripts": "git://github.com/reactiveops/k8s-scripts.git#v3.4.1"
+    "k8s-scripts": "git://github.com/FairwindsOps/k8s-scripts.git#v3.4.1"
   }
 }


### PR DESCRIPTION
Remaining mentions: 
```
./circle.yml:    EXTERNAL_REGISTRY_BASE_DOMAIN: quay.io/reactiveops
./deploy/kubernetes-curator.deployment.yml.j2:        image: quay.io/reactiveops/docker-curator:master
```